### PR TITLE
Add simple web UI with model dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ python app/app.py
 
 The server listens on port `5000`.
 
+Open `http://localhost:5000/` in a browser to use the simple web interface. It
+lets you choose a model from a dropdown and chat with it directly.
+
 ### Docker
 
 Build and run using Docker:

--- a/app/app.py
+++ b/app/app.py
@@ -1,10 +1,16 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template
 import os
 
 app = Flask(__name__)
 
 # in-memory storage of conversations by session_id
 conversations = {}
+
+
+@app.route('/')
+def index():
+    """Simple web UI for chatting with different models."""
+    return render_template('index.html')
 
 
 def call_model(model, messages):

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>LLM Chat</title>
+</head>
+<body>
+    <h1>LLM Chat</h1>
+    <form id="chat-form">
+        <label for="model">Model:</label>
+        <select id="model" name="model">
+            <option value="chatgpt">ChatGPT</option>
+            <option value="claude">Claude</option>
+            <option value="mistral">Mistral</option>
+            <option value="llama">LLama</option>
+            <option value="perplexity">Perplexity</option>
+        </select>
+        <br/>
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" rows="4" cols="50"></textarea>
+        <br/>
+        <button type="submit">Send</button>
+    </form>
+    <pre id="response"></pre>
+    <script>
+        document.getElementById('chat-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const model = document.getElementById('model').value;
+            const message = document.getElementById('message').value;
+            const resp = await fetch('/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ session_id: 'web', model, message })
+            });
+            const data = await resp.json();
+            document.getElementById('response').textContent = data.response;
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal HTML page containing a dropdown for model selection
- expose `/` route in the Flask app to serve the new page
- document opening the web interface in README

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_b_686194abd2e0832db8587ae4902c3959