### PR TITLE
Fix openai usage for v1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,18 @@ Build and run using Docker:
 
 ```bash
 docker build -t llm-chat .
-docker run -p 5000:5000 -e OPENAI_API_KEY=... llm-chat
+docker run -p 5000:5000 --env-file .env llm-chat
+```
+
+Place your API keys in a `.env` file in the project root with values like:
+
+```
+OPENAI_API_KEY=...
+ANTHROPIC_API_KEY=...
+MISTRAL_API_KEY=...
+LLAMA_API_BASE=...
+LLAMA_API_KEY=...
+PERPLEXITY_API_KEY=...
 ```
 
 ## Endpoints

--- a/app/app.py
+++ b/app/app.py
@@ -16,10 +16,10 @@ def index():
 def call_model(model, messages):
     """Dispatch call to different LLM providers."""
     if model in ("chatgpt", "gpt-3.5-turbo", "openai"):
-        import openai
-        openai.api_key = os.getenv("OPENAI_API_KEY")
-        resp = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
-        return resp.choices[0].message["content"]
+        from openai import OpenAI
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        resp = client.chat.completions.create(model="gpt-3.5-turbo", messages=messages)
+        return resp.choices[0].message.content
     elif model == "claude":
         import anthropic
         client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
@@ -35,17 +35,15 @@ def call_model(model, messages):
         resp = client.chat(model="mistral-tiny", messages=messages)
         return resp.choices[0].message.content
     elif model == "llama":
-        import openai
-        openai.api_base = os.getenv("LLAMA_API_BASE")
-        openai.api_key = os.getenv("LLAMA_API_KEY")
-        resp = openai.ChatCompletion.create(model="llama", messages=messages)
-        return resp.choices[0].message["content"]
+        from openai import OpenAI
+        client = OpenAI(base_url=os.getenv("LLAMA_API_BASE"), api_key=os.getenv("LLAMA_API_KEY"))
+        resp = client.chat.completions.create(model="llama", messages=messages)
+        return resp.choices[0].message.content
     elif model == "perplexity":
-        import openai
-        openai.api_base = os.getenv("PERPLEXITY_API_BASE", "https://api.perplexity.ai")
-        openai.api_key = os.getenv("PERPLEXITY_API_KEY")
-        resp = openai.ChatCompletion.create(model="pplx-70b-online", messages=messages)
-        return resp.choices[0].message["content"]
+        from openai import OpenAI
+        client = OpenAI(base_url=os.getenv("PERPLEXITY_API_BASE", "https://api.perplexity.ai"), api_key=os.getenv("PERPLEXITY_API_KEY"))
+        resp = client.chat.completions.create(model="pplx-70b-online", messages=messages)
+        return resp.choices[0].message.content
     else:
         return "Unknown model"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask
-openai
+openai>=1.0
 anthropic
 mistralai


### PR DESCRIPTION
## Summary
- update call_model function to use openai>=1 syntax
- pin openai>=1.0 in requirements
- document using a `.env` file for Docker

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_b_6861a1931c8c832dbb31ebe191b20bc2