### PR TITLE
Add request/response history view

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ PERPLEXITY_MODEL=pplx-70b-online
 
 - `POST /chat` – send a chat message.
 - `POST /summarize` – summarize a block of text.
+- `GET /history` – retrieve the last 20 prompt/response pairs for a session.
 
 Both endpoints accept JSON with at least `session_id`, `model`, and the user
 content. History for a session is stored in memory and automatically included

--- a/app/app.py
+++ b/app/app.py
@@ -68,7 +68,7 @@ def chat():
     response_content = call_model(model, history)
 
     history.append({'role': 'assistant', 'content': response_content})
-    return jsonify({'response': response_content, 'history': history})
+    return jsonify({'response': response_content, 'history': history[-40:]})
 
 
 @app.route('/summarize', methods=['POST'])
@@ -87,6 +87,23 @@ def summarize():
 
     history.append({'role': 'assistant', 'content': response_content})
     return jsonify({'summary': response_content, 'history': history})
+
+
+@app.route('/history', methods=['GET'])
+def get_history():
+    """Return the last 20 prompt/response pairs for a session."""
+    session_id = request.args.get('session_id', 'default')
+    history = conversations.get(session_id, [])
+    # Grab the last 40 messages (20 pairs)
+    recent = history[-40:]
+    pairs = []
+    for i in range(0, len(recent), 2):
+        if i + 1 < len(recent):
+            pairs.append({
+                'prompt': recent[i]['content'],
+                'response': recent[i + 1]['content']
+            })
+    return jsonify({'history': pairs})
 
 
 if __name__ == '__main__':

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,6 +22,8 @@
         <button type="submit">Send</button>
     </form>
     <pre id="response"></pre>
+    <h2>History (last 20 prompts and responses)</h2>
+    <pre id="history"></pre>
     <script>
         document.getElementById('chat-form').addEventListener('submit', async (e) => {
             e.preventDefault();
@@ -34,7 +36,18 @@
             });
             const data = await resp.json();
             document.getElementById('response').textContent = data.response;
+            await loadHistory();
         });
+
+        async function loadHistory() {
+            const resp = await fetch('/history?session_id=web');
+            const data = await resp.json();
+            const lines = data.history.map(pair => `User: ${pair.prompt}\nAssistant: ${pair.response}`).join('\n\n');
+            document.getElementById('history').textContent = lines;
+        }
+
+        // load existing history on page load
+        loadHistory();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- return only the last 20 prompt/response pairs from `/chat`
- add `/history` endpoint to retrieve recent conversation
- display request/response history in the web UI
- document the new endpoint in README

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_b_68630da92804832db9a7a342de066b47