### PR TITLE
Add model selection per provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ python app/app.py
 The server listens on port `5000`.
 
 Open `http://localhost:5000/` in a browser to use the simple web interface. It
-lets you choose a model from a dropdown and chat with it directly.
+lets you choose a provider and then select one of the available models defined
+in `app/data/models.json`.
 
 ### Docker
 
@@ -55,10 +56,11 @@ PERPLEXITY_MODEL=pplx-70b-online
 
 ## Endpoints
 
+- `GET /models` – return the available models for each provider.
 - `POST /chat` – send a chat message.
 - `POST /summarize` – summarize a block of text.
 - `GET /history` – retrieve the last 20 prompt/response pairs for a session.
 
-Both endpoints accept JSON with at least `session_id`, `model`, and the user
-content. History for a session is stored in memory and automatically included
-in subsequent calls for that session.
+`/chat` and `/summarize` accept JSON with `session_id`, `provider` and
+`model_name` along with the user content. History for a session is stored in
+memory and automatically included in subsequent calls for that session.

--- a/app/data/models.json
+++ b/app/data/models.json
@@ -1,0 +1,7 @@
+{
+  "chatgpt": ["gpt-3.5-turbo", "gpt-4o"],
+  "claude": ["claude-3-haiku-20240307", "claude-3-opus-20240229"],
+  "mistral": ["mistral-tiny", "mistral-small"],
+  "llama": ["llama", "llama-3"],
+  "perplexity": ["llama-3.1-sonar-small-32k-online", "llama-3.1-sonar-large-128k-online"]
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,14 +8,10 @@
     <img src="{{ url_for('static', filename='QKSS AI LinkedIn Banner v3.png') }}" alt="QKSS AI banner" style="max-width:100%;height:auto;" />
     <h1>LLM Chat</h1>
     <form id="chat-form">
+        <label for="llm">LLM:</label>
+        <select id="llm" name="llm"></select>
         <label for="model">Model:</label>
-        <select id="model" name="model">
-            <option value="chatgpt">ChatGPT</option>
-            <option value="claude">Claude</option>
-            <option value="mistral">Mistral</option>
-            <option value="llama">LLama</option>
-            <option value="perplexity">Perplexity</option>
-        </select>
+        <select id="model" name="model"></select>
         <br/>
         <label for="message">Message:</label>
         <textarea id="message" name="message" rows="4" cols="50"></textarea>
@@ -26,19 +22,39 @@
     <h2>History (last 20 prompts and responses)</h2>
     <pre id="history"></pre>
     <script>
+        let models = {};
+
         document.getElementById('chat-form').addEventListener('submit', async (e) => {
             e.preventDefault();
+            const provider = document.getElementById('llm').value;
             const model = document.getElementById('model').value;
             const message = document.getElementById('message').value;
             const resp = await fetch('/chat', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ session_id: 'web', model, message })
+                body: JSON.stringify({ session_id: 'web', provider, model_name: model, message })
             });
             const data = await resp.json();
             document.getElementById('response').textContent = data.response;
             await loadHistory();
         });
+
+        async function loadModels() {
+            const resp = await fetch('/models');
+            models = await resp.json();
+            const llmSelect = document.getElementById('llm');
+            llmSelect.innerHTML = Object.keys(models).map(m => `<option value="${m}">${m}</option>`).join('');
+            updateModelOptions();
+        }
+
+        function updateModelOptions() {
+            const llm = document.getElementById('llm').value;
+            const modelSelect = document.getElementById('model');
+            const opts = models[llm] || [];
+            modelSelect.innerHTML = opts.map(m => `<option value="${m}">${m}</option>`).join('');
+        }
+
+        document.getElementById('llm').addEventListener('change', updateModelOptions);
 
         async function loadHistory() {
             const resp = await fetch('/history?session_id=web');
@@ -47,7 +63,8 @@
             document.getElementById('history').textContent = lines;
         }
 
-        // load existing history on page load
+        // load existing history and model list on page load
+        loadModels();
         loadHistory();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- define available models in `app/data/models.json`
- expose `/models` endpoint
- allow specifying provider and model in `/chat` and `/summarize`
- update client UI to load models per provider
- document how to use new model selection

## Testing
- `python -m py_compile app/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686312dd2800832d8e1101ddced985bf