### PR TITLE
Render markdown in frontend

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -29,11 +29,13 @@
             <button type="submit" class="btn btn-primary"><i class="bi bi-send-fill me-1"></i>Send</button>
         </div>
     </form>
-    <pre id="response" class="mt-4"></pre>
+    <div id="response" class="mt-4"></div>
+    <div id="status" class="text-success"></div>
     <h2 class="mt-5">History (last 20 prompts and responses)</h2>
     <pre id="history"></pre>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
     let models = {};
 
@@ -48,7 +50,8 @@
             body: JSON.stringify({ session_id: 'web', provider, model_name: model, message })
         });
         const data = await resp.json();
-        document.getElementById('response').textContent = data.response;
+        document.getElementById('response').innerHTML = marked.parse(data.response);
+        document.getElementById('status').textContent = 'API response received.';
         await loadHistory();
     });
 


### PR DESCRIPTION
## Summary
- display API responses as HTML rendered from markdown
- show simple status text when an API response is received

## Testing
- `python -m py_compile app/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68631fb97474832db70b94ab7f632880