### PR TITLE
Render history as markdown

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -32,7 +32,7 @@
     <div id="response" class="mt-4"></div>
     <div id="status" class="text-success"></div>
     <h2 class="mt-5">History (last 20 prompts and responses)</h2>
-    <pre id="history"></pre>
+    <div id="history" class="vstack gap-4"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -106,8 +106,12 @@
     async function loadHistory() {
         const resp = await fetch('/history?session_id=web');
         const data = await resp.json();
-        const lines = data.history.map(pair => `User: ${pair.prompt}\nAssistant: ${pair.response}`).join('\n\n');
-        document.getElementById('history').textContent = lines;
+        const html = data.history.map(pair => {
+            const prompt = marked.parse(pair.prompt);
+            const response = marked.parse(pair.response);
+            return `<div><p><strong>User:</strong></p>${prompt}<p><strong>Assistant:</strong></p>${response}</div>`;
+        }).join('<hr>');
+        document.getElementById('history').innerHTML = html;
     }
 
     // load existing history and model list on page load


### PR DESCRIPTION
## Summary
- show chat history inside a div container
- render each history item with `marked.parse()` like the main message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686322657d98832d93303d502b60acec