### PR TITLE
Fix macro import in index template

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,4 +1,4 @@
-{% from 'macros.html' import bootstrap_dropdown %}
+{% from 'macros.html' import bootstrap_dropdown, bootstrap_check_dropdown %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- import `bootstrap_check_dropdown` macro used by the index template

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_b_6863e97f7ff8832d888349b5eb708af0