### PR TITLE
Add gene variant search page

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -42,6 +42,12 @@ def index():
     return render_template('index.html')
 
 
+@app.route('/gene')
+def gene_page():
+    """Page for looking up gene/variant information."""
+    return render_template('gene.html')
+
+
 @app.route('/models')
 def list_models():
     """Return the available models for each provider."""

--- a/app/templates/gene.html
+++ b/app/templates/gene.html
@@ -1,0 +1,117 @@
+{% from 'macros.html' import bootstrap_dropdown, bootstrap_check_dropdown %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Gene Variant Search</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+</head>
+<body>
+<div class="container py-4">
+    <img src="{{ url_for('static', filename='QKSS AI LinkedIn Banner v3.png') }}" alt="QKSS AI banner" class="img-fluid mb-4" />
+    <h1 class="mb-4">Gene Variant Search</h1>
+    <form id="gene-form" class="vstack gap-3">
+        <div>
+            <label for="gene" class="form-label">Gene</label>
+            <input type="text" id="gene" name="gene" class="form-control" required />
+        </div>
+        <div>
+            <label for="variant" class="form-label">Variant</label>
+            <input type="text" id="variant" name="variant" class="form-control" required />
+        </div>
+        <div>
+            <label class="form-label">Status</label>
+            {{ bootstrap_dropdown('status', 'Select Status') }}
+        </div>
+        <div>
+            <label class="form-label">LLM / Model</label>
+            {{ bootstrap_check_dropdown('combo', 'Select Models', 'bi-check2-square') }}
+        </div>
+        <div>
+            <button type="submit" class="btn btn-primary">Search</button>
+        </div>
+    </form>
+    <div id="response" class="mt-4"></div>
+    <div id="status-msg" class="text-success"></div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    const statuses = ['Benign', 'Likely Benign', 'VUS', 'Likely Pathogenic', 'Pathogenic'];
+    let models = {};
+
+    function loadStatus() {
+        const menu = document.getElementById('status-menu');
+        let html = statuses.map(s => `<li><a class="dropdown-item" href="#" data-value="${s}">${s}</a></li>`).join('');
+        menu.innerHTML = html;
+        menu.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', e => {
+                e.preventDefault();
+                document.getElementById('status-label').textContent = a.dataset.value;
+                document.getElementById('status').value = a.dataset.value;
+            });
+        });
+    }
+
+    async function loadModels() {
+        const resp = await fetch('/models');
+        models = await resp.json();
+        const menu = document.getElementById('combo-menu');
+        let html = '';
+        Object.entries(models).forEach(([provider, list]) => {
+            list.forEach(info => {
+                const model = typeof info === 'string' ? info : info.name;
+                const id = `cmb-${provider}-${model}`.replace(/[^a-z0-9]/gi, '-');
+                html += `<div class="form-check"><input class="form-check-input" type="checkbox" value="${provider}|${model}" id="${id}"><label class="form-check-label" for="${id}">${provider} - ${model}</label></div>`;
+            });
+        });
+        menu.innerHTML = html;
+        document.getElementById('combo-label').textContent = 'Select Models';
+    }
+
+    document.getElementById('combo-menu').addEventListener('change', () => {
+        const count = document.querySelectorAll('#combo-menu input:checked').length;
+        document.getElementById('combo-label').textContent = count ? `${count} selected` : 'Select Models';
+    });
+
+    document.getElementById('gene-form').addEventListener('submit', async e => {
+        e.preventDefault();
+        const gene = document.getElementById('gene').value;
+        const variant = document.getElementById('variant').value;
+        const status = document.getElementById('status').value;
+        const selected = Array.from(document.querySelectorAll('#combo-menu input:checked')).map(cb => cb.value.split('|'));
+        const prompt = `You are a genetic counselor who is guiding a patient through a genetic screening. Please search for the gene ${gene} and variant ${variant} and summarize what this gene and variant mean to the patient. The status is ${status}.`;
+        const respDiv = document.getElementById('response');
+        respDiv.innerHTML = '';
+        document.getElementById('status-msg').textContent = 'Processing...';
+        for (const [provider, model] of selected) {
+            const container = document.createElement('div');
+            container.className = 'border p-3 mb-3 rounded';
+            container.innerHTML = `<h5>${provider} - ${model}</h5><div>Loading...</div>`;
+            respDiv.appendChild(container);
+            try {
+                const resp = await fetch('/chat', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        session_id: 'gene',
+                        provider: provider,
+                        model_name: model,
+                        message: prompt
+                    })
+                });
+                const data = await resp.json();
+                container.querySelector('div').textContent = data.response;
+            } catch (err) {
+                container.querySelector('div').textContent = 'Error: ' + err;
+            }
+        }
+        document.getElementById('status-msg').textContent = 'API responses received.';
+    });
+
+    loadStatus();
+    loadModels();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `/gene` route to display gene variant search page
- add new `gene.html` template for entering gene, variant, status and running chat requests using selected LLM models

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_b_68653d378870832d9050b32e0db6962a