### PR TITLE
Fix gene page markdown rendering

### DIFF
--- a/app/templates/gene.html
+++ b/app/templates/gene.html
@@ -41,6 +41,7 @@
     <div id="status-msg" class="text-success"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
     const statuses = ['Benign', 'Likely Benign', 'VUS', 'Likely Pathogenic', 'Pathogenic'];
     const recipients = ['self', 'child', 'spouse', 'parent'];
@@ -125,7 +126,7 @@
                     })
                 });
                 const data = await resp.json();
-                container.querySelector('div').textContent = data.response;
+                container.querySelector('div').innerHTML = marked.parse(data.response);
             } catch (err) {
                 container.querySelector('div').textContent = 'Error: ' + err;
             }


### PR DESCRIPTION
## Summary
- render gene chat responses as Markdown
- load `marked` on the gene variant page

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_b_68656436bd94832db492ba7fd5986608