### PR TITLE
Revamp gene workflow with sequential pages

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -168,21 +168,35 @@ def gene_page():
 def conditions_page():
     gene = request.args.get('gene', '')
     variant = request.args.get('variant', '')
+    provider = request.args.get('provider', 'chatgpt')
+    model_name = request.args.get('model_name') or default_model(provider)
     conditions = fetch_medline_conditions(gene, variant)
     summary = ''
     if conditions:
         prompt = (
             'Summarize the following medical conditions for a patient:\n' + '\n'.join(conditions)
         )
-        summary = call_model('chatgpt', [{'role': 'user', 'content': prompt}], default_model('chatgpt'))
+        summary = call_model(provider, [{'role': 'user', 'content': prompt}], model_name)
     if request.args.get('json') == '1' or request.accept_mimetypes['application/json'] > request.accept_mimetypes['text/html']:
         return jsonify({'conditions': conditions, 'summary': summary})
-    return render_template('conditions.html', conditions=conditions, summary=summary)
+    return render_template(
+        'conditions.html',
+        conditions=conditions,
+        summary=summary,
+        gene=gene,
+        variant=variant,
+    )
 
 
 @app.route('/chatpage')
 def chat_page():
-    return render_template('chat.html')
+    gene = request.args.get('gene', '')
+    variant = request.args.get('variant', '')
+    status = request.args.get('status', '')
+    recipient = request.args.get('recipient', 'self')
+    return render_template(
+        'chat.html', gene=gene, variant=variant, status=status, recipient=recipient
+    )
 
 
 @app.route('/models')

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -1,4 +1,4 @@
-{% from 'macros.html' import bootstrap_dropdown, bootstrap_check_dropdown %}
+{% from 'macros.html' import bootstrap_check_dropdown %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -12,6 +12,7 @@
 <div class="container py-4">
     <img src="{{ url_for('static', filename='QKSS AI LinkedIn Banner v3.png') }}" alt="QKSS AI banner" class="img-fluid mb-4" />
     <h1 class="mb-4">Ask the LLM</h1>
+    <p id="info" class="fw-bold"></p>
     <form id="chat-form" class="vstack gap-3">
         <div>
             <label class="form-label">LLM / Model</label>
@@ -20,10 +21,6 @@
         <div>
             <label for="message" class="form-label">Message</label>
             <textarea id="message" name="message" rows="4" class="form-control"></textarea>
-        </div>
-        <div>
-            <label for="file" class="form-label">Upload Files (optional)</label>
-            <input type="file" id="file" name="files" multiple class="form-control" />
         </div>
         <div>
             <button type="submit" class="btn btn-primary"><i class="bi bi-send-fill me-1"></i>Send</button>
@@ -38,46 +35,58 @@
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
     let models = {};
+    const params = new URLSearchParams(window.location.search);
+    const gene = params.get('gene') || '';
+    const variant = params.get('variant') || '';
+    const status = params.get('status') || '';
+    const recipient = params.get('recipient') || 'self';
+    const sessionId = 'chat-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+    let provider = 'chatgpt';
+    let model = 'gpt-3.5-turbo';
+    document.getElementById('info').textContent = `Gene: ${gene}  Variant: ${variant}  Status: ${status}`;
 
     document.getElementById('chat-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const messageBox = document.getElementById('message');
-        const fileInput = document.getElementById('file');
         const message = messageBox.value;
-        const selected = Array.from(document.querySelectorAll('#combo-menu input:checked'))
-            .map(cb => cb.value.split('|'));
+        const selected = Array.from(document.querySelectorAll('#combo-menu input:checked')).map(cb => cb.value.split('|'));
+        if (selected.length) {
+            [provider, model] = selected[0];
+        }
 
-        // clear the textarea and show a processing indicator
         messageBox.value = '';
         messageBox.placeholder = 'Processing the message...';
         document.getElementById('status').textContent = 'Processing the message...';
         const respDiv = document.getElementById('response');
         respDiv.innerHTML = '';
-        for (const [provider, model] of selected) {
-            const container = document.createElement('div');
-            container.className = 'border p-3 mb-3 rounded';
-            container.innerHTML = `<h5>${provider} - ${model}</h5><div>Loading...</div>`;
-            respDiv.appendChild(container);
-            try {
-                const fd = new FormData();
-                fd.append('session_id', 'web');
-                fd.append('provider', provider);
-                fd.append('model_name', model);
-                fd.append('message', message);
-                [...fileInput.files].forEach(f => fd.append('files', f));
-                const resp = await fetch('/chat', {
-                    method: 'POST',
-                    body: fd
-                });
-                const data = await resp.json();
-                container.querySelector('div').innerHTML = marked.parse(data.response);
-            } catch (err) {
-                container.querySelector('div').textContent = 'Error: ' + err;
-            }
+
+        const container = document.createElement('div');
+        container.className = 'border p-3 mb-3 rounded';
+        container.innerHTML = `<h5>${provider} - ${model}</h5><div>Loading...</div>`;
+        respDiv.appendChild(container);
+        try {
+            const resp = await fetch('/gene_chat', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    session_id: sessionId,
+                    gene: gene,
+                    variant: variant,
+                    status: status,
+                    recipient: recipient,
+                    provider: provider,
+                    model_name: model,
+                    question: message
+                })
+            });
+            const data = await resp.json();
+            container.querySelector('div').innerHTML = marked.parse(data.response);
+            renderHistory(data.history);
+        } catch (err) {
+            container.querySelector('div').textContent = 'Error: ' + err;
         }
         document.getElementById('status').textContent = 'API responses received.';
         messageBox.placeholder = '';
-        await loadHistory();
     });
 
     async function loadModels() {
@@ -102,7 +111,7 @@
     });
 
     async function loadHistory() {
-        const resp = await fetch('/history?session_id=web');
+        const resp = await fetch(`/history?session_id=${sessionId}`);
         const data = await resp.json();
         const html = data.history.map(pair => {
             const prompt = marked.parse(pair.prompt);

--- a/app/templates/conditions.html
+++ b/app/templates/conditions.html
@@ -1,4 +1,4 @@
-{% from 'macros.html' import bootstrap_dropdown %}
+{% from 'macros.html' import bootstrap_check_dropdown %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -10,26 +10,83 @@
 <body>
 <div class="container py-4">
     <h1 class="mb-4">Condition Summary</h1>
-    {% if conditions %}
-        <h5>Conditions found on MedlinePlus</h5>
-        <ul>
-        {% for c in conditions %}
-            <li>{{ c }}</li>
-        {% endfor %}
-        </ul>
-    {% else %}
-        <p>No conditions were found for this query.</p>
-    {% endif %}
-    {% if summary %}
-        <h5 class="mt-4">Summary</h5>
-        <div>{{ summary|safe }}</div>
-    {% endif %}
-    <button id="next-btn" class="btn btn-primary mt-4">Next</button>
+    <form id="model-form" class="vstack gap-3">
+        <div>
+            <label class="form-label">LLM / Model</label>
+            {{ bootstrap_check_dropdown('combo', 'Select Models', 'bi-check2-square') }}
+        </div>
+        <button type="submit" class="btn btn-primary">Get Summary</button>
+    </form>
+    <div id="summary" class="mt-4"></div>
+    <button id="next-btn" class="btn btn-secondary mt-2" style="display:none;">Next</button>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
-    document.getElementById('next-btn').addEventListener('click', () => {
-        window.location.href = '/chatpage';
+    let models = {};
+    const params = new URLSearchParams(window.location.search);
+    const gene = params.get('gene') || '';
+    const variant = params.get('variant') || '';
+    const status = params.get('status') || '';
+    const recipient = params.get('recipient') || 'self';
+    let provider = 'chatgpt';
+    let model = 'gpt-3.5-turbo';
+
+    async function loadModels() {
+        const resp = await fetch('/models');
+        models = await resp.json();
+        const menu = document.getElementById('combo-menu');
+        let html = '';
+        Object.entries(models).forEach(([p, list]) => {
+            list.forEach(info => {
+                const m = typeof info === 'string' ? info : info.name;
+                const id = `cmb-${p}-${m}`.replace(/[^a-z0-9]/gi, '-');
+                html += `<div class="form-check"><input class="form-check-input" type="checkbox" value="${p}|${m}" id="${id}"><label class="form-check-label" for="${id}">${p} - ${m}</label></div>`;
+            });
+        });
+        menu.innerHTML = html;
+        document.getElementById('combo-label').textContent = 'Select Models';
+    }
+
+    document.getElementById('combo-menu').addEventListener('change', () => {
+        const checked = Array.from(document.querySelectorAll('#combo-menu input:checked')).map(cb => cb.value.split('|'));
+        if (checked.length) {
+            [provider, model] = checked[0];
+        }
+        const count = checked.length;
+        document.getElementById('combo-label').textContent = count ? `${count} selected` : 'Select Models';
     });
+
+    document.getElementById('model-form').addEventListener('submit', async e => {
+        e.preventDefault();
+        const summaryDiv = document.getElementById('summary');
+        summaryDiv.textContent = 'Loading...';
+        try {
+            const url = `/conditions?gene=${encodeURIComponent(gene)}&variant=${encodeURIComponent(variant)}&provider=${encodeURIComponent(provider)}&model_name=${encodeURIComponent(model)}&json=1`;
+            const resp = await fetch(url);
+            const data = await resp.json();
+            let html = '';
+            if (data.conditions && data.conditions.length) {
+                html += '<h5>Conditions found on MedlinePlus</h5><ul>' + data.conditions.map(c => `<li>${c}</li>`).join('') + '</ul>';
+            } else {
+                html += '<p>No conditions were found for this query.</p>';
+            }
+            if (data.summary) {
+                html += `<h5 class="mt-4">Summary</h5><div>${marked.parse(data.summary)}</div>`;
+            }
+            summaryDiv.innerHTML = html;
+            document.getElementById('next-btn').style.display = 'block';
+        } catch (err) {
+            summaryDiv.textContent = 'Error: ' + err;
+        }
+    });
+
+    document.getElementById('next-btn').addEventListener('click', () => {
+        const q = new URLSearchParams({gene, variant, status, recipient}).toString();
+        window.location.href = '/chatpage?' + q;
+    });
+
+    loadModels();
 </script>
 </body>
 </html>

--- a/app/templates/gene.html
+++ b/app/templates/gene.html
@@ -1,4 +1,4 @@
-{% from 'macros.html' import bootstrap_dropdown, bootstrap_check_dropdown %}
+{% from 'macros.html' import bootstrap_dropdown %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -29,26 +29,12 @@
             <label class="form-label">Status</label>
             {{ bootstrap_dropdown('status', 'Select Status') }}
         </div>
-        <div>
-            <label class="form-label">LLM / Model</label>
-            {{ bootstrap_check_dropdown('combo', 'Select Models', 'bi-check2-square') }}
-        </div>
         <div class="d-flex gap-2">
             <button type="submit" class="btn btn-primary">Search</button>
         </div>
     </form>
     <div id="response" class="mt-4"></div>
-    <button type="button" id="conditions-btn" class="btn btn-secondary mt-2" style="display:none;">Condition Summary</button>
-    <div id="conditions-response" class="mt-4"></div>
-    <form id="question-form" class="vstack gap-3 mt-4" style="display:none;">
-        <div>
-            <label for="question" class="form-label">Follow-up Question</label>
-            <textarea id="question" rows="3" class="form-control"></textarea>
-        </div>
-        <button type="submit" class="btn btn-primary">Ask</button>
-    </form>
-    <h2 class="mt-4" id="history-title" style="display:none;">History</h2>
-    <div id="history" class="vstack gap-3"></div>
+    <button type="button" id="next-btn" class="btn btn-secondary mt-2" style="display:none;">Next</button>
     <div id="status-msg" class="text-success"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
@@ -56,9 +42,8 @@
 <script>
     const statuses = ['Benign', 'Likely Benign', 'VUS', 'Likely Pathogenic', 'Pathogenic'];
     const recipients = ['self', 'child', 'spouse', 'parent'];
-    let models = {};
     const sessionId = 'gene-' + Date.now() + '-' + Math.random().toString(36).slice(2);
-    let current = { gene: '', variant: '', status: '', recipient: 'self', provider: '', model: '' };
+    let nextParams = '';
 
     function loadStatus() {
         const menu = document.getElementById('status-menu');
@@ -89,127 +74,50 @@
         });
     }
 
-    async function loadModels() {
-        const resp = await fetch('/models');
-        models = await resp.json();
-        const menu = document.getElementById('combo-menu');
-        let html = '';
-        Object.entries(models).forEach(([provider, list]) => {
-            list.forEach(info => {
-                const model = typeof info === 'string' ? info : info.name;
-                const id = `cmb-${provider}-${model}`.replace(/[^a-z0-9]/gi, '-');
-                html += `<div class="form-check"><input class="form-check-input" type="checkbox" value="${provider}|${model}" id="${id}"><label class="form-check-label" for="${id}">${provider} - ${model}</label></div>`;
-            });
-        });
-        menu.innerHTML = html;
-        document.getElementById('combo-label').textContent = 'Select Models';
-    }
+    async function sendGeneChat() {
+        const gene = document.getElementById('gene').value;
+        const variant = document.getElementById('variant').value;
+        const status = document.getElementById('status').value;
+        const recipient = document.getElementById('recipient').value || 'self';
 
-    document.getElementById('combo-menu').addEventListener('change', () => {
-        const count = document.querySelectorAll('#combo-menu input:checked').length;
-        document.getElementById('combo-label').textContent = count ? `${count} selected` : 'Select Models';
-    });
+        nextParams = `gene=${encodeURIComponent(gene)}&variant=${encodeURIComponent(variant)}&status=${encodeURIComponent(status)}&recipient=${encodeURIComponent(recipient)}`;
 
-    async function sendGeneChat(question = '') {
         const respDiv = document.getElementById('response');
-        respDiv.innerHTML = '';
-        document.getElementById('status-msg').textContent = 'Processing...';
-        const container = document.createElement('div');
-        container.className = 'border p-3 mb-3 rounded';
-        container.innerHTML = `<h5>${current.provider} - ${current.model}</h5><div>Loading...</div>`;
-        respDiv.appendChild(container);
+        respDiv.textContent = 'Loading...';
         try {
             const resp = await fetch('/gene_chat', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({
                     session_id: sessionId,
-                    gene: current.gene,
-                    variant: current.variant,
-                    status: current.status,
-                    recipient: current.recipient,
-                    provider: current.provider,
-                    model_name: current.model,
-                    question: question
+                    gene: gene,
+                    variant: variant,
+                    status: status,
+                    recipient: recipient,
+                    provider: 'chatgpt',
+                    model_name: 'gpt-3.5-turbo'
                 })
             });
             const data = await resp.json();
-            container.querySelector('div').innerHTML = marked.parse(data.response);
-            renderHistory(data.history);
+            respDiv.innerHTML = marked.parse(data.response);
+            document.getElementById('next-btn').style.display = 'block';
         } catch (err) {
-            container.querySelector('div').textContent = 'Error: ' + err;
+            respDiv.textContent = 'Error: ' + err;
         }
-        document.getElementById('status-msg').textContent = 'API responses received.';
-        document.getElementById('history-title').style.display = 'block';
-        if (!question) {
-            document.getElementById('conditions-btn').style.display = 'block';
-            document.getElementById('conditions-response').innerHTML = '';
-            document.getElementById('question-form').style.display = 'none';
-        }
-    }
-
-    function renderHistory(history) {
-        const pairs = [];
-        for (let i = 0; i < history.length; i += 2) {
-            if (i + 1 < history.length) {
-                pairs.push({prompt: history[i].content, response: history[i+1].content});
-            }
-        }
-        const html = pairs.map(p => `<div class="border border-dark p-3 mb-3 rounded"><p><strong>User:</strong></p>${marked.parse(p.prompt)}<p><strong>Assistant:</strong></p>${marked.parse(p.response)}</div>`).join('');
-        document.getElementById('history').innerHTML = html;
+        document.getElementById('status-msg').textContent = '';
     }
 
     document.getElementById('gene-form').addEventListener('submit', async e => {
         e.preventDefault();
-        current.gene = document.getElementById('gene').value;
-        current.variant = document.getElementById('variant').value;
-        current.status = document.getElementById('status').value;
-        current.recipient = document.getElementById('recipient').value || 'self';
-        const selected = Array.from(document.querySelectorAll('#combo-menu input:checked')).map(cb => cb.value.split('|'));
-        if (!selected.length) {
-            alert('Please select a model');
-            return;
-        }
-        [current.provider, current.model] = selected[0];
-        await sendGeneChat('');
+        await sendGeneChat();
     });
 
-    document.getElementById('question-form').addEventListener('submit', async e => {
-        e.preventDefault();
-        const q = document.getElementById('question').value;
-        document.getElementById('question').value = '';
-        await sendGeneChat(q);
+    document.getElementById('next-btn').addEventListener('click', () => {
+        window.location.href = '/conditions?' + nextParams;
     });
 
     loadStatus();
-    loadModels();
     loadRecipient();
-
-    document.getElementById('conditions-btn').addEventListener('click', async () => {
-        const gene = document.getElementById('gene').value;
-        const variant = document.getElementById('variant').value;
-        const respDiv = document.getElementById('conditions-response');
-        respDiv.textContent = 'Loading...';
-        try {
-            const url = `/conditions?gene=${encodeURIComponent(gene)}&variant=${encodeURIComponent(variant)}&json=1`;
-            const resp = await fetch(url);
-            const data = await resp.json();
-            let html = '';
-            if (data.conditions && data.conditions.length) {
-                html += '<h5>Conditions found on MedlinePlus</h5><ul>' +
-                    data.conditions.map(c => `<li>${c}</li>`).join('') + '</ul>';
-            } else {
-                html += '<p>No conditions were found for this query.</p>';
-            }
-            if (data.summary) {
-                html += `<h5 class="mt-4">Summary</h5><div>${marked.parse(data.summary)}</div>`;
-            }
-            respDiv.innerHTML = html;
-            document.getElementById('question-form').style.display = 'block';
-        } catch (err) {
-            respDiv.textContent = 'Error: ' + err;
-        }
-    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify gene search page and default to ChatGPT
- allow selecting model on condition summary page
- pass gene parameters through to final chat page
- use gene-specific chat endpoint for Q&A

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_b_68658e0b8160832dbaf47523b1e1be6d