### PR TITLE
Add provider selection to gene screen and fix chat page history

### DIFF
--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -41,8 +41,8 @@
     const status = params.get('status') || '';
     const recipient = params.get('recipient') || 'self';
     const sessionId = 'chat-' + Date.now() + '-' + Math.random().toString(36).slice(2);
-    let provider = 'chatgpt';
-    let model = 'gpt-3.5-turbo';
+    let provider = params.get('provider') || 'chatgpt';
+    let model = params.get('model_name') || 'gpt-3.5-turbo';
     document.getElementById('info').textContent = `Gene: ${gene}  Variant: ${variant}  Status: ${status}`;
 
     document.getElementById('chat-form').addEventListener('submit', async (e) => {
@@ -103,10 +103,20 @@
         });
         menu.innerHTML = html;
         document.getElementById('combo-label').textContent = 'Select Models';
+        const id = `cmb-${provider}-${model}`.replace(/[^a-z0-9]/gi, '-');
+        const cb = document.getElementById(id);
+        if (cb) {
+            cb.checked = true;
+            document.getElementById('combo-label').textContent = '1 selected';
+        }
     }
 
     document.getElementById('combo-menu').addEventListener('change', () => {
-        const count = document.querySelectorAll('#combo-menu input:checked').length;
+        const checked = Array.from(document.querySelectorAll('#combo-menu input:checked')).map(cb => cb.value.split('|'));
+        if (checked.length) {
+            [provider, model] = checked[0];
+        }
+        const count = checked.length;
         document.getElementById('combo-label').textContent = count ? `${count} selected` : 'Select Models';
     });
 
@@ -119,6 +129,16 @@
             return `<div class="border border-dark p-3 mb-3 rounded"><p><strong>User:</strong></p>${prompt}<p><strong>Assistant:</strong></p>${response}</div>`;
         }).join('');
         document.getElementById('history').innerHTML = html;
+    }
+
+    function renderHistory(history) {
+        const pairs = [];
+        for (let i = 0; i + 1 < history.length; i += 2) {
+            const prompt = marked.parse(history[i].content);
+            const response = marked.parse(history[i + 1].content);
+            pairs.push(`<div class="border border-dark p-3 mb-3 rounded"><p><strong>User:</strong></p>${prompt}<p><strong>Assistant:</strong></p>${response}</div>`);
+        }
+        document.getElementById('history').innerHTML = pairs.join('');
     }
 
     // load existing history and model list on page load

--- a/app/templates/conditions.html
+++ b/app/templates/conditions.html
@@ -29,8 +29,8 @@
     const variant = params.get('variant') || '';
     const status = params.get('status') || '';
     const recipient = params.get('recipient') || 'self';
-    let provider = 'chatgpt';
-    let model = 'gpt-3.5-turbo';
+    let provider = params.get('provider') || 'chatgpt';
+    let model = params.get('model_name') || 'gpt-3.5-turbo';
 
     async function loadModels() {
         const resp = await fetch('/models');
@@ -46,6 +46,12 @@
         });
         menu.innerHTML = html;
         document.getElementById('combo-label').textContent = 'Select Models';
+        const id = `cmb-${provider}-${model}`.replace(/[^a-z0-9]/gi, '-');
+        const cb = document.getElementById(id);
+        if (cb) {
+            cb.checked = true;
+            document.getElementById('combo-label').textContent = '1 selected';
+        }
     }
 
     document.getElementById('combo-menu').addEventListener('change', () => {
@@ -82,7 +88,7 @@
     });
 
     document.getElementById('next-btn').addEventListener('click', () => {
-        const q = new URLSearchParams({gene, variant, status, recipient}).toString();
+        const q = new URLSearchParams({gene, variant, status, recipient, provider, model_name: model}).toString();
         window.location.href = '/chatpage?' + q;
     });
 

--- a/app/templates/gene.html
+++ b/app/templates/gene.html
@@ -1,4 +1,4 @@
-{% from 'macros.html' import bootstrap_dropdown %}
+{% from 'macros.html' import bootstrap_dropdown, bootstrap_check_dropdown %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -29,6 +29,10 @@
             <label class="form-label">Status</label>
             {{ bootstrap_dropdown('status', 'Select Status') }}
         </div>
+        <div>
+            <label class="form-label">LLM / Model</label>
+            {{ bootstrap_check_dropdown('combo', 'Select Models', 'bi-check2-square') }}
+        </div>
         <div class="d-flex gap-2">
             <button type="submit" class="btn btn-primary">Search</button>
         </div>
@@ -44,6 +48,9 @@
     const recipients = ['self', 'child', 'spouse', 'parent'];
     const sessionId = 'gene-' + Date.now() + '-' + Math.random().toString(36).slice(2);
     let nextParams = '';
+    let models = {};
+    let provider = 'chatgpt';
+    let model = 'gpt-3.5-turbo';
 
     function loadStatus() {
         const menu = document.getElementById('status-menu');
@@ -74,13 +81,44 @@
         });
     }
 
+    async function loadModels() {
+        const resp = await fetch('/models');
+        models = await resp.json();
+        const menu = document.getElementById('combo-menu');
+        let html = '';
+        Object.entries(models).forEach(([p, list]) => {
+            list.forEach(info => {
+                const m = typeof info === 'string' ? info : info.name;
+                const id = `cmb-${p}-${m}`.replace(/[^a-z0-9]/gi, '-');
+                html += `<div class="form-check"><input class="form-check-input" type="checkbox" value="${p}|${m}" id="${id}"><label class="form-check-label" for="${id}">${p} - ${m}</label></div>`;
+            });
+        });
+        menu.innerHTML = html;
+        document.getElementById('combo-label').textContent = 'Select Models';
+        const id = `cmb-${provider}-${model}`.replace(/[^a-z0-9]/gi, '-');
+        const cb = document.getElementById(id);
+        if (cb) {
+            cb.checked = true;
+            document.getElementById('combo-label').textContent = '1 selected';
+        }
+    }
+
+    document.getElementById('combo-menu').addEventListener('change', () => {
+        const checked = Array.from(document.querySelectorAll('#combo-menu input:checked')).map(cb => cb.value.split('|'));
+        if (checked.length) {
+            [provider, model] = checked[0];
+        }
+        const count = checked.length;
+        document.getElementById('combo-label').textContent = count ? `${count} selected` : 'Select Models';
+    });
+
     async function sendGeneChat() {
         const gene = document.getElementById('gene').value;
         const variant = document.getElementById('variant').value;
         const status = document.getElementById('status').value;
         const recipient = document.getElementById('recipient').value || 'self';
 
-        nextParams = `gene=${encodeURIComponent(gene)}&variant=${encodeURIComponent(variant)}&status=${encodeURIComponent(status)}&recipient=${encodeURIComponent(recipient)}`;
+        nextParams = `gene=${encodeURIComponent(gene)}&variant=${encodeURIComponent(variant)}&status=${encodeURIComponent(status)}&recipient=${encodeURIComponent(recipient)}&provider=${encodeURIComponent(provider)}&model_name=${encodeURIComponent(model)}`;
 
         const respDiv = document.getElementById('response');
         respDiv.textContent = 'Loading...';
@@ -94,8 +132,8 @@
                     variant: variant,
                     status: status,
                     recipient: recipient,
-                    provider: 'chatgpt',
-                    model_name: 'gpt-3.5-turbo'
+                    provider: provider,
+                    model_name: model
                 })
             });
             const data = await resp.json();
@@ -118,6 +156,7 @@
 
     loadStatus();
     loadRecipient();
+    loadModels();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add check dropdown for model selection on the gene search page
- preserve provider and model across navigation
- parse provider and model from query parameters on later pages
- fix missing `renderHistory` function on chat page

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_b_686590d022e4832d89dfa349c942d9c9