### PR TITLE
Enable concurrent model requests in UI

### DIFF
--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -59,35 +59,37 @@
         const respDiv = document.getElementById('response');
         respDiv.innerHTML = '';
         let lastHistory = null;
-        for (const [prov, mod] of queries) {
+        const promises = queries.map(([prov, mod]) => {
             provider = prov;
             model = mod;
             const container = document.createElement('div');
             container.className = 'border p-3 mb-3 rounded';
             container.innerHTML = `<h5>${prov} - ${mod}</h5><div>Loading...</div>`;
             respDiv.appendChild(container);
-            try {
-                const resp = await fetch('/gene_chat', {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({
-                        session_id: sessionId,
-                        gene: gene,
-                        variant: variant,
-                        status: status,
-                        recipient: recipient,
-                        provider: prov,
-                        model_name: mod,
-                        question: message
-                    })
-                });
-                const data = await resp.json();
+            return fetch('/gene_chat', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    session_id: sessionId,
+                    gene: gene,
+                    variant: variant,
+                    status: status,
+                    recipient: recipient,
+                    provider: prov,
+                    model_name: mod,
+                    question: message
+                })
+            })
+            .then(resp => resp.json())
+            .then(data => {
                 container.querySelector('div').innerHTML = marked.parse(data.response);
                 lastHistory = data.history;
-            } catch (err) {
+            })
+            .catch(err => {
                 container.querySelector('div').textContent = 'Error: ' + err;
-            }
-        }
+            });
+        });
+        await Promise.all(promises);
         if (lastHistory) {
             renderHistory(lastHistory);
         }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -53,28 +53,27 @@
         document.getElementById('status').textContent = 'Processing the message...';
         const respDiv = document.getElementById('response');
         respDiv.innerHTML = '';
-        for (const [provider, model] of selected) {
+        const promises = selected.map(([provider, model]) => {
             const container = document.createElement('div');
             container.className = 'border p-3 mb-3 rounded';
             container.innerHTML = `<h5>${provider} - ${model}</h5><div>Loading...</div>`;
             respDiv.appendChild(container);
-            try {
-                const fd = new FormData();
-                fd.append('session_id', 'web');
-                fd.append('provider', provider);
-                fd.append('model_name', model);
-                fd.append('message', message);
-                [...fileInput.files].forEach(f => fd.append('files', f));
-                const resp = await fetch('/chat', {
-                    method: 'POST',
-                    body: fd
+            const fd = new FormData();
+            fd.append('session_id', 'web');
+            fd.append('provider', provider);
+            fd.append('model_name', model);
+            fd.append('message', message);
+            [...fileInput.files].forEach(f => fd.append('files', f));
+            return fetch('/chat', { method: 'POST', body: fd })
+                .then(resp => resp.json())
+                .then(data => {
+                    container.querySelector('div').innerHTML = marked.parse(data.response);
+                })
+                .catch(err => {
+                    container.querySelector('div').textContent = 'Error: ' + err;
                 });
-                const data = await resp.json();
-                container.querySelector('div').innerHTML = marked.parse(data.response);
-            } catch (err) {
-                container.querySelector('div').textContent = 'Error: ' + err;
-            }
-        }
+        });
+        await Promise.all(promises);
         document.getElementById('status').textContent = 'API responses received.';
         messageBox.placeholder = '';
         await loadHistory();


### PR DESCRIPTION
## Summary
- allow the web UI to call multiple models concurrently
- update both `index.html` and `chat.html` JavaScript loops to use `Promise.all`

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_b_6866b0666ec4832db700c72ed86d1ac2