### PR TITLE
Support multiple model responses

### DIFF
--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -43,6 +43,7 @@
     const sessionId = 'chat-' + Date.now() + '-' + Math.random().toString(36).slice(2);
     let provider = params.get('provider') || 'chatgpt';
     let model = params.get('model_name') || 'gpt-3.5-turbo';
+    let historySession = `${sessionId}-${provider}-${model}`;
     document.getElementById('info').textContent = `Gene: ${gene}  Variant: ${variant}  Status: ${status}`;
 
     document.getElementById('chat-form').addEventListener('submit', async (e) => {
@@ -59,9 +60,12 @@
         const respDiv = document.getElementById('response');
         respDiv.innerHTML = '';
         let lastHistory = null;
-        const promises = queries.map(([prov, mod]) => {
+        const promises = queries.map(([prov, mod], idx) => {
             provider = prov;
             model = mod;
+            if (idx === 0) {
+                historySession = `${sessionId}-${prov}-${mod}`;
+            }
             const container = document.createElement('div');
             container.className = 'border p-3 mb-3 rounded';
             container.innerHTML = `<h5>${prov} - ${mod}</h5><div>Loading...</div>`;
@@ -70,7 +74,7 @@
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({
-                    session_id: sessionId,
+                    session_id: `${sessionId}-${prov}-${mod}`,
                     gene: gene,
                     variant: variant,
                     status: status,
@@ -83,7 +87,9 @@
             .then(resp => resp.json())
             .then(data => {
                 container.querySelector('div').innerHTML = marked.parse(data.response);
-                lastHistory = data.history;
+                if (!lastHistory) {
+                    lastHistory = data.history;
+                }
             })
             .catch(err => {
                 container.querySelector('div').textContent = 'Error: ' + err;
@@ -129,7 +135,7 @@
     });
 
     async function loadHistory() {
-        const resp = await fetch(`/history?session_id=${sessionId}`);
+        const resp = await fetch(`/history?session_id=${historySession}`);
         const data = await resp.json();
         const html = data.history.map(pair => {
             const prompt = marked.parse(pair.prompt);

--- a/app/templates/gene.html
+++ b/app/templates/gene.html
@@ -118,30 +118,48 @@
         const status = document.getElementById('status').value;
         const recipient = document.getElementById('recipient').value || 'self';
 
+        const selected = Array.from(document.querySelectorAll('#combo-menu input:checked'))
+            .map(cb => cb.value.split('|'));
+        if (selected.length) {
+            [provider, model] = selected[0];
+        } else {
+            selected.push([provider, model]);
+        }
+
         nextParams = `gene=${encodeURIComponent(gene)}&variant=${encodeURIComponent(variant)}&status=${encodeURIComponent(status)}&recipient=${encodeURIComponent(recipient)}&provider=${encodeURIComponent(provider)}&model_name=${encodeURIComponent(model)}`;
 
         const respDiv = document.getElementById('response');
-        respDiv.textContent = 'Loading...';
-        try {
-            const resp = await fetch('/gene_chat', {
+        respDiv.innerHTML = '';
+
+        const promises = selected.map(([prov, mod]) => {
+            const container = document.createElement('div');
+            container.className = 'border p-3 mb-3 rounded';
+            container.innerHTML = `<h5>${prov} - ${mod}</h5><div>Loading...</div>`;
+            respDiv.appendChild(container);
+            return fetch('/gene_chat', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({
-                    session_id: sessionId,
+                    session_id: `${sessionId}-${prov}-${mod}`,
                     gene: gene,
                     variant: variant,
                     status: status,
                     recipient: recipient,
-                    provider: provider,
-                    model_name: model
+                    provider: prov,
+                    model_name: mod
                 })
+            })
+            .then(resp => resp.json())
+            .then(data => {
+                container.querySelector('div').innerHTML = marked.parse(data.response);
+            })
+            .catch(err => {
+                container.querySelector('div').textContent = 'Error: ' + err;
             });
-            const data = await resp.json();
-            respDiv.innerHTML = marked.parse(data.response);
-            document.getElementById('next-btn').style.display = 'block';
-        } catch (err) {
-            respDiv.textContent = 'Error: ' + err;
-        }
+        });
+
+        await Promise.all(promises);
+        document.getElementById('next-btn').style.display = 'block';
         document.getElementById('status-msg').textContent = '';
     }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -38,6 +38,9 @@
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
     let models = {};
+    let provider = 'chatgpt';
+    let model = 'gpt-3.5-turbo';
+    let historySession = `web-${provider}-${model}`;
 
     document.getElementById('chat-form').addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -53,15 +56,20 @@
         document.getElementById('status').textContent = 'Processing the message...';
         const respDiv = document.getElementById('response');
         respDiv.innerHTML = '';
-        const promises = selected.map(([provider, model]) => {
+        const promises = selected.map(([prov, mod], idx) => {
+            provider = prov;
+            model = mod;
+            if (idx === 0) {
+                historySession = `web-${prov}-${mod}`;
+            }
             const container = document.createElement('div');
             container.className = 'border p-3 mb-3 rounded';
-            container.innerHTML = `<h5>${provider} - ${model}</h5><div>Loading...</div>`;
+            container.innerHTML = `<h5>${prov} - ${mod}</h5><div>Loading...</div>`;
             respDiv.appendChild(container);
             const fd = new FormData();
-            fd.append('session_id', 'web');
-            fd.append('provider', provider);
-            fd.append('model_name', model);
+            fd.append('session_id', `web-${prov}-${mod}`);
+            fd.append('provider', prov);
+            fd.append('model_name', mod);
             fd.append('message', message);
             [...fileInput.files].forEach(f => fd.append('files', f));
             return fetch('/chat', { method: 'POST', body: fd })
@@ -101,7 +109,7 @@
     });
 
     async function loadHistory() {
-        const resp = await fetch('/history?session_id=web');
+        const resp = await fetch(`/history?session_id=${historySession}`);
         const data = await resp.json();
         const html = data.history.map(pair => {
             const prompt = marked.parse(pair.prompt);


### PR DESCRIPTION
## Summary
- allow /gene page to call several providers and models at once
- isolate chat sessions by provider/model to prevent invalid message history
- update Ask the LLM page for multiple concurrent responses
- apply the same session handling on the main chat page

## Testing
- `python -m py_compile app/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6866b4011900832d843d29ea77661ea2