### PR TITLE
Add navigation back buttons

### DIFF
--- a/app/templates/conditions.html
+++ b/app/templates/conditions.html
@@ -18,7 +18,10 @@
         <button type="submit" class="btn btn-primary">Get Summary</button>
     </form>
     <div id="summary" class="mt-4"></div>
-    <button id="next-btn" class="btn btn-secondary mt-2" style="display:none;">Next</button>
+    <div id="nav-buttons" class="d-flex gap-2 mt-2" style="display:none;">
+        <button type="button" id="back-btn" class="btn btn-secondary">Back</button>
+        <button type="button" id="next-btn" class="btn btn-secondary">Next</button>
+    </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -81,10 +84,14 @@
                 html += `<h5 class="mt-4">Summary</h5><div>${marked.parse(data.summary)}</div>`;
             }
             summaryDiv.innerHTML = html;
-            document.getElementById('next-btn').style.display = 'block';
+            document.getElementById('nav-buttons').style.display = 'flex';
         } catch (err) {
             summaryDiv.textContent = 'Error: ' + err;
         }
+    });
+
+    document.getElementById('back-btn').addEventListener('click', () => {
+        window.history.back();
     });
 
     document.getElementById('next-btn').addEventListener('click', () => {

--- a/app/templates/gene.html
+++ b/app/templates/gene.html
@@ -38,7 +38,10 @@
         </div>
     </form>
     <div id="response" class="mt-4"></div>
-    <button type="button" id="next-btn" class="btn btn-secondary mt-2" style="display:none;">Next</button>
+    <div id="nav-buttons" class="d-flex gap-2 mt-2" style="display:none;">
+        <button type="button" id="back-btn" class="btn btn-secondary">Back</button>
+        <button type="button" id="next-btn" class="btn btn-secondary">Next</button>
+    </div>
     <div id="status-msg" class="text-success"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
@@ -159,13 +162,17 @@
         });
 
         await Promise.all(promises);
-        document.getElementById('next-btn').style.display = 'block';
+        document.getElementById('nav-buttons').style.display = 'flex';
         document.getElementById('status-msg').textContent = '';
     }
 
     document.getElementById('gene-form').addEventListener('submit', async e => {
         e.preventDefault();
         await sendGeneChat();
+    });
+
+    document.getElementById('back-btn').addEventListener('click', () => {
+        window.history.back();
     });
 
     document.getElementById('next-btn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add back button next to each page's "Next" button
- display navigation buttons after results load
- hook back button to browser history

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_b_6866b784fea8832da635cc933b2c8a62