### PR TITLE
Add Tavus conversational agent integration

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -12,6 +12,7 @@ import json
 import base64
 import requests
 from bs4 import BeautifulSoup
+from tavus_agent import start_conversation, close_conversation
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "devkey")
@@ -454,6 +455,33 @@ def chat_page():
 def list_models():
     """Return the available models for each provider."""
     return jsonify(AVAILABLE_MODELS)
+
+
+@app.route("/tavus")
+@login_required
+def tavus_page():
+    """Render the Tavus conversational agent page."""
+    return render_template("tavus.html")
+
+
+@app.route("/tavus/start")
+@login_required
+def tavus_start():
+    """Start a new Tavus conversation."""
+    force_new = request.args.get("new") == "1"
+    try:
+        data = start_conversation(force_new=force_new)
+        return jsonify(data)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/tavus/close")
+@login_required
+def tavus_close():
+    """End the Tavus conversation and go back to the home page."""
+    close_conversation()
+    return redirect(url_for("gene_page"))
 
 
 def call_model(provider: str, messages, model_name: str, files=None):

--- a/app/tavus_agent.py
+++ b/app/tavus_agent.py
@@ -1,0 +1,60 @@
+import os
+import requests
+
+TAVUS_API_KEY = os.getenv("TAVUS_API_KEY")
+TAVUS_REPLICA_ID = os.getenv("TAVUS_REPLICA_ID", "r4317e64d25a")
+TAVUS_PERSONA_ID = os.getenv("TAVUS_PERSONA_ID", "p70ec11f62ec")
+
+# Optional configuration for saving conversation recordings to S3
+TAVUS_RECORDING_S3_BUCKET_NAME = os.getenv("TAVUS_RECORDING_S3_BUCKET_NAME")
+TAVUS_RECORDING_S3_BUCKET_REGION = os.getenv("TAVUS_RECORDING_S3_BUCKET_REGION")
+TAVUS_AWS_ASSUME_ROLE_ARN = os.getenv("TAVUS_AWS_ASSUME_ROLE_ARN")
+
+HEADERS = {
+    "Content-Type": "application/json",
+    "x-api-key": TAVUS_API_KEY,
+}
+
+DATA = {
+    "replica_id": TAVUS_REPLICA_ID,
+    "conversation_name": "Olivia",
+    "persona_id": TAVUS_PERSONA_ID,
+    "custom_greeting": "Hello, Welcome to Legacy Forever",
+    "conversational_context": (
+        "You are StorySeeker, an engaging, empathetic AI host whose job is to learn about each guest’s life story, passions, and proudest achievements. Speak in a warm, inviting tone. Guide the conversation with open‑ended questions that encourage reflection and storytelling. Be patient, listen actively, and follow up based on the person’s answers. Keep the flow natural—as if chatting over coffee.\n\n"
+        "Opening Greeting:\n\nHello! I’m StorySeeker. I’m excited to hear your story today. Let’s start by getting to know each other—feel free to share as much as you like.\n"
+        "..."  # shortened for brevity
+    ),
+    "properties": {
+        "enable_closed_captions": False,
+        "enable_recording": True,
+        "recording_s3_bucket_name": TAVUS_RECORDING_S3_BUCKET_NAME,
+        "recording_s3_bucket_region": TAVUS_RECORDING_S3_BUCKET_REGION,
+        "aws_assume_role_arn": TAVUS_AWS_ASSUME_ROLE_ARN,
+    },
+}
+
+API_URL = os.getenv("TAVUS_API_URL", "https://tavusapi.com/v2/conversations")
+
+_CONVERSATION_CACHE = None
+
+
+def start_conversation(force_new: bool = False):
+    """Start a conversation using the Tavus API."""
+    global _CONVERSATION_CACHE
+    if _CONVERSATION_CACHE is not None and not force_new:
+        return _CONVERSATION_CACHE
+
+    if not TAVUS_API_KEY:
+        raise RuntimeError("TAVUS_API_KEY not set")
+
+    response = requests.post(API_URL, headers=HEADERS, json=DATA)
+    response.raise_for_status()
+    _CONVERSATION_CACHE = response.json()
+    return _CONVERSATION_CACHE
+
+
+def close_conversation():
+    """Clear any cached conversation info."""
+    global _CONVERSATION_CACHE
+    _CONVERSATION_CACHE = None

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -30,6 +30,10 @@
     <div id="status" class="text-success"></div>
     <h2 class="mt-5">History (last 20 prompts and responses)</h2>
     <div id="history" class="vstack gap-4"></div>
+    <div id="nav-buttons" class="d-flex gap-2 mt-2" style="display:none;">
+        <button type="button" id="back-btn" class="btn btn-secondary">Back</button>
+        <button type="button" id="next-btn" class="btn btn-secondary">Next</button>
+    </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -101,6 +105,7 @@
         }
         document.getElementById('status').textContent = 'API responses received.';
         messageBox.placeholder = '';
+        document.getElementById('nav-buttons').style.display = 'flex';
     });
 
     async function loadModels() {
@@ -159,6 +164,13 @@
     // load existing history and model list on page load
     loadModels();
     loadHistory();
+
+    document.getElementById('back-btn').addEventListener('click', () => {
+        window.history.back();
+    });
+    document.getElementById('next-btn').addEventListener('click', () => {
+        window.location.href = '/tavus';
+    });
 </script>
 </body>
 </html>

--- a/app/templates/tavus.html
+++ b/app/templates/tavus.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Tavus Conversation</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="m-0">Tavus</h1>
+      <div>
+        <a href="/" class="btn btn-secondary btn-sm me-2">Back</a>
+        <a href="/logout" class="btn btn-outline-secondary btn-sm">Logout</a>
+      </div>
+    </div>
+    <div class="alert alert-info">Hello, I'm Tavus. Let's begin whenever you're ready.</div>
+    <div id="conversation" class="mb-3"></div>
+    <div id="transcript" class="border rounded p-3 mb-3" style="height:200px; overflow-y:auto;"></div>
+    <div>
+      <a href="/tavus/close" class="btn btn-danger">Close Conversation</a>
+    </div>
+  </div>
+  <script src="https://unpkg.com/@daily-co/daily-js"></script>
+  <script>
+    fetch('/tavus/start')
+      .then(r => r.json())
+      .then(data => {
+        const transcript = document.getElementById('transcript');
+        transcript.textContent = JSON.stringify(data, null, 2);
+        if (data.conversation_url) {
+          const callFrame = window.DailyIframe.createFrame(document.getElementById('conversation'), {
+            iframeStyle: {
+              width: '100%',
+              height: '600px'
+            }
+          });
+          callFrame.join({ url: data.conversation_url }).then(() => {
+            callFrame.startRecording({ recordingType: 'cloud' });
+          });
+        }
+      })
+      .catch(err => {
+        document.getElementById('transcript').textContent = 'Error: ' + err;
+      });
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `tavus_agent` helper for creating Tavus conversations
- create `/tavus` routes for starting and closing conversations
- include new Tavus conversation page
- let the chat page navigate to the Tavus page

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f0f0e2e08331bf1051772fb2a369