### PR TITLE
Add conversational agent to chat page

### DIFF
--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -32,11 +32,18 @@
     <div id="history" class="vstack gap-4"></div>
     <div id="nav-buttons" class="d-flex gap-2 mt-2" style="display:none;">
         <button type="button" id="back-btn" class="btn btn-secondary">Back</button>
-        <button type="button" id="next-btn" class="btn btn-secondary">Next</button>
+        <button type="button" id="next-btn" class="btn btn-secondary">Start Conversation</button>
+    </div>
+    <div id="tavus-section" class="mt-5" style="display:none;">
+        <h2 class="mb-3">Conversation</h2>
+        <div id="conversation" class="mb-3"></div>
+        <div id="transcript" class="border rounded p-3 mb-3" style="height:200px; overflow-y:auto;"></div>
+        <button type="button" id="close-convo-btn" class="btn btn-danger">Close Conversation</button>
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://unpkg.com/@daily-co/daily-js"></script>
 <script>
     let models = {};
     const params = new URLSearchParams(window.location.search);
@@ -168,8 +175,31 @@
     document.getElementById('back-btn').addEventListener('click', () => {
         window.history.back();
     });
-    document.getElementById('next-btn').addEventListener('click', () => {
-        window.location.href = '/tavus';
+
+    async function startConversation() {
+        const section = document.getElementById('tavus-section');
+        section.style.display = 'block';
+        try {
+            const resp = await fetch('/tavus/start');
+            const data = await resp.json();
+            const transcript = document.getElementById('transcript');
+            transcript.textContent = JSON.stringify(data, null, 2);
+            if (data.conversation_url) {
+                const callFrame = window.DailyIframe.createFrame(document.getElementById('conversation'), {
+                    iframeStyle: { width: '100%', height: '600px' }
+                });
+                await callFrame.join({ url: data.conversation_url });
+                callFrame.startRecording({ recordingType: 'cloud' });
+            }
+        } catch (err) {
+            document.getElementById('transcript').textContent = 'Error: ' + err;
+        }
+    }
+
+    document.getElementById('next-btn').addEventListener('click', startConversation);
+    document.getElementById('close-convo-btn').addEventListener('click', async () => {
+        await fetch('/tavus/close');
+        window.location.reload();
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- embed the Tavus conversation interface directly in `chat.html`
- start video conversation from the chat page

## Testing
- `python -m py_compile app/app.py app/tavus_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f6ab4ac8833185285e6783d016cd