### PR TITLE
Redirect root to login and update navigation

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -364,6 +364,11 @@ def logout():
 
 
 @app.route("/")
+def root():
+    """Landing page - redirect to login."""
+    return redirect(url_for("login"))
+
+@app.route("/chat")
 @login_required
 def index():
     """Simple web UI for chatting with different models."""

--- a/app/templates/conditions.html
+++ b/app/templates/conditions.html
@@ -118,8 +118,7 @@
     });
 
     document.getElementById('next-btn').addEventListener('click', () => {
-        const q = new URLSearchParams({gene, variant, status, recipient, provider, model_name: model}).toString();
-        window.location.href = '/chatpage?' + q;
+        window.location.href = '/tavus';
     });
 
     loadModels();

--- a/app/templates/tavus.html
+++ b/app/templates/tavus.html
@@ -10,7 +10,7 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
       <h1 class="m-0">Tavus</h1>
       <div>
-        <a href="/" class="btn btn-secondary btn-sm me-2">Back</a>
+        <a href="/gene" class="btn btn-secondary btn-sm me-2">Back</a>
         <a href="/logout" class="btn btn-outline-secondary btn-sm">Logout</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- redirect `/` to login and move chat page to `/chat`
- send users from conditions page directly to Tavus
- fix Tavus page back-link to go to gene search

## Testing
- `python -m py_compile app/app.py app/tavus_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6883fa30e6308331b6912d406ba2ca4a