### PR TITLE
Enhance introduction layout and load model options

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -3,3 +3,5 @@
   min-height: 100%;
 }
 .card { border-radius: 12px; }
+
+.intro-wrap { max-width: 1200px; margin-inline: auto; }

--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -3,110 +3,114 @@
 
 {% block content %}
 <div class="page-soft-bg">
-  <div class="container py-5">
-    <div class="text-center mb-4">
-      <h1 class="display-6 fw-semibold mb-2">Tell Us About Your Genetics Test</h1>
-      <p class="text-muted mb-0">We’ll help you understand your genetic test results with personalized, compassionate guidance tailored to your situation.</p>
-    </div>
+  <div class="container-xxl py-5">
+    <div class="intro-wrap">
+      <div class="text-center mb-4">
+        <h1 class="display-6 fw-semibold mb-2">Tell Us About Your Genetics Test</h1>
+        <p class="text-muted mb-0">We’ll help you understand your genetic test results with personalized, compassionate guidance tailored to your situation.</p>
+      </div>
 
-    <form method="post" action="{{ url_for('introduction') }}">
-      {{ csrf_field() if csrf_field is defined }}
+      <form method="post" action="{{ url_for('introduction') }}">
+        {{ csrf_field() if csrf_field is defined }}
 
-      <div class="row g-4 mb-4">
-        <!-- Who is this test for -->
-        <div class="col-md-6">
-          <div class="card border-0 shadow-sm h-100">
-            <div class="card-body">
-              <h5 class="card-title mb-1">Who is this test for?</h5>
-              <p class="text-muted small mb-3">This helps us provide more personalized guidance and advice.</p>
+        <div class="row g-4 mb-4">
+          <!-- Who is this test for -->
+          <div class="col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+              <div class="card-body">
+                <h5 class="card-title mb-1">Who is this test for?</h5>
+                <p class="text-muted small mb-3">This helps us provide more personalized guidance and advice.</p>
 
-              <fieldset>
-                <legend class="visually-hidden">Recipient</legend>
-                <div class="vstack gap-2">
-                  {% set options = [
-                    ('myself','Myself'),
-                    ('parent','My Parent'),
-                    ('partner','My Partner'),
-                    ('child','My Child'),
-                    ('sibling','My Sibling'),
-                    ('other','Other Family Member')
-                  ] %}
-                  {% for val,label in options %}
-                  <div class="form-check">
-                    <input class="form-check-input {% if errors.recipient %}is-invalid{% endif %}"
-                           type="radio" name="recipient" id="recipient_{{ val }}"
-                           value="{{ val }}" {% if form_data.recipient == val %}checked{% endif %}>
-                    <label class="form-check-label" for="recipient_{{ val }}">{{ label }}</label>
+                <fieldset>
+                  <legend class="visually-hidden">Recipient</legend>
+                  <div class="row row-cols-1 row-cols-md-3 g-2">
+                    {% set options = [
+                      ('myself','Myself'),
+                      ('parent','My Parent'),
+                      ('partner','My Partner'),
+                      ('child','My Child'),
+                      ('sibling','My Sibling'),
+                      ('other','Other Family Member')
+                    ] %}
+                    {% for val,label in options %}
+                    <div class="col">
+                      <div class="form-check">
+                        <input class="form-check-input {% if errors.recipient %}is-invalid{% endif %}"
+                               type="radio" name="recipient" id="recipient_{{ val }}"
+                               value="{{ val }}" {% if form_data.recipient == val %}checked{% endif %}>
+                        <label class="form-check-label" for="recipient_{{ val }}">{{ label }}</label>
+                      </div>
+                    </div>
+                    {% endfor %}
                   </div>
-                  {% endfor %}
                   {% if errors.recipient %}
                     <div class="invalid-feedback d-block">{{ errors.recipient }}</div>
                   {% endif %}
-                </div>
-              </fieldset>
-            </div>
-          </div>
-        </div>
-
-        <!-- Genetic Test Report -->
-        <div class="col-md-6">
-          <div class="card border-0 shadow-sm h-100">
-            <div class="card-body">
-              <h5 class="card-title mb-1">Genetic Test Report</h5>
-              <p class="text-muted small mb-3">Do you have your genetic test report available?</p>
-
-              <fieldset class="mb-3">
-                <legend class="visually-hidden">Report availability</legend>
-                <div class="vstack gap-2">
-                  <div class="form-check">
-                    <input class="form-check-input" type="radio" name="has_report" id="has_report_yes"
-                           value="yes" {% if form_data.has_report == 'yes' %}checked{% endif %}>
-                    <label class="form-check-label" for="has_report_yes">Yes, I can upload it</label>
-                  </div>
-                  <div class="form-check">
-                    <input class="form-check-input" type="radio" name="has_report" id="has_report_no"
-                           value="no" {% if form_data.has_report == 'no' %}checked{% endif %}>
-                    <label class="form-check-label" for="has_report_no">No, I’ll enter details manually</label>
-                  </div>
-                </div>
-              </fieldset>
-
-              <div class="mb-3">
-                <label for="gene" class="form-label">Gene</label>
-                <input type="text" id="gene" name="gene"
-                       class="form-control {% if errors.gene %}is-invalid{% endif %}"
-                       placeholder="e.g., BRCA1, CFTR, TP53" value="{{ form_data.gene or '' }}">
-                {% if errors.gene %}<div class="invalid-feedback">{{ errors.gene }}</div>{% endif %}
-              </div>
-
-              <div class="mb-3">
-                <label for="variant" class="form-label">Mutation/Variant</label>
-                <textarea id="variant" name="variant" rows="2"
-                          class="form-control {% if errors.variant %}is-invalid{% endif %}"
-                          placeholder="e.g., c.185delAG, p.Arg72Pro">{{ form_data.variant or '' }}</textarea>
-                {% if errors.variant %}<div class="invalid-feedback">{{ errors.variant }}</div>{% endif %}
-              </div>
-
-              <div>
-                <label for="classification" class="form-label">Classification Status</label>
-                <select id="classification" name="classification"
-                        class="form-select {% if errors.classification %}is-invalid{% endif %}">
-                  <option value="" disabled {% if not form_data.classification %}selected{% endif %}>
-                    Select classification
-                  </option>
-                  {% for opt in classification_options %}
-                  <option value="{{ opt.value }}"
-                    {% if form_data.classification == opt.value %}selected{% endif %}>
-                    {{ opt.label }}
-                  </option>
-                  {% endfor %}
-                </select>
-                {% if errors.classification %}<div class="invalid-feedback">{{ errors.classification }}</div>{% endif %}
+                </fieldset>
               </div>
             </div>
           </div>
+
+          <!-- Genetic Test Report -->
+          <div class="col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+              <div class="card-body">
+                <h5 class="card-title mb-1">Genetic Test Report</h5>
+                <p class="text-muted small mb-3">Do you have your genetic test report available?</p>
+
+                <fieldset class="mb-3">
+                  <legend class="visually-hidden">Report availability</legend>
+                  {% set has_report = form_data.has_report or 'no' %}
+                  <div class="vstack gap-2">
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="has_report" id="has_report_yes"
+                             value="yes" {% if has_report == 'yes' %}checked{% endif %}>
+                      <label class="form-check-label" for="has_report_yes">Yes, I can upload it</label>
+                    </div>
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="has_report" id="has_report_no"
+                             value="no" {% if has_report == 'no' %}checked{% endif %}>
+                      <label class="form-check-label" for="has_report_no">No, I’ll enter details manually</label>
+                    </div>
+                  </div>
+                </fieldset>
+
+                <div class="mb-3">
+                  <label for="gene" class="form-label">Gene</label>
+                  <input type="text" id="gene" name="gene"
+                         class="form-control {% if errors.gene %}is-invalid{% endif %}"
+                         placeholder="e.g., BRCA1, CFTR, TP53" value="{{ form_data.gene or '' }}">
+                  {% if errors.gene %}<div class="invalid-feedback">{{ errors.gene }}</div>{% endif %}
+                </div>
+
+                <div class="mb-3">
+                  <label for="variant" class="form-label">Mutation/Variant</label>
+                  <textarea id="variant" name="variant" rows="2"
+                            class="form-control {% if errors.variant %}is-invalid{% endif %}"
+                            placeholder="e.g., c.185delAG, p.Arg72Pro">{{ form_data.variant or '' }}</textarea>
+                  {% if errors.variant %}<div class="invalid-feedback">{{ errors.variant }}</div>{% endif %}
+                </div>
+
+                <div>
+                  <label for="classification" class="form-label">Classification Status</label>
+                  <select id="classification" name="classification"
+                          class="form-select {% if errors.classification %}is-invalid{% endif %}">
+                    <option value="" disabled {% if not form_data.classification %}selected{% endif %}>
+                      Select classification
+                    </option>
+                    {% for opt in classification_options %}
+                    <option value="{{ opt.value }}"
+                      {% if form_data.classification == opt.value %}selected{% endif %}>
+                      {{ opt.label }}
+                    </option>
+                    {% endfor %}
+                  </select>
+                  {% if errors.classification %}<div class="invalid-feedback">{{ errors.classification }}</div>{% endif %}
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
 
       <!-- Counselor -->
       <div class="card border-0 shadow-sm mb-4">
@@ -133,6 +137,7 @@
         <button type="submit" class="btn btn-primary btn-lg px-5">Continue to Analysis</button>
       </div>
     </form>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Expand `/introduction` content width and style with a new `.intro-wrap` wrapper
- Arrange recipient radios in a responsive 3x2 grid and default genetic report to "No"
- Load AI counselor options from `models.json` and redirect post-login to `/introduction`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c1e8cc6083318203ea994a2cb526